### PR TITLE
add synth discount stream, gets data from invoices

### DIFF
--- a/tap_stripe/client.py
+++ b/tap_stripe/client.py
@@ -178,6 +178,9 @@ class stripeStream(RESTStream):
                 # using prices API instead of plans API
                 if self.name == "plans":
                     url = base_url + f"/v1/prices/{record_id}"
+                # discounts is a synthetic stream, it uses data from invoices
+                if self.name == "discounts":
+                    url = base_url + f"/v1/invoices/{record_id}"
                 else:
                     url = base_url + f"/v1/{self.name}/{record['id']}"
                 params = {}

--- a/tap_stripe/tap.py
+++ b/tap_stripe/tap.py
@@ -32,6 +32,7 @@ from tap_stripe.streams import (
     RefundsStream,
     PayoutReportsStream,
     DisputesIssuingStream,
+    Discounts
 )
 
 STREAM_TYPES = [
@@ -61,6 +62,7 @@ STREAM_TYPES = [
     RefundsStream,
     PayoutReportsStream,
     DisputesIssuingStream,
+    Discounts
 ]
 
 


### PR DESCRIPTION
Add synthetic stream "discounts", it gets all discounts from invoices and invoices lines items. It works for full syncs and incremental syncs and it's independent from invoices stream. 