### PR TITLE
feature/hgi-10568 | Added automated linting functionality with Ruff

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,18 @@
+name: Lint
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install ruff
+        run: python -m pip install ruff
+      - name: Lint
+        run: ruff check .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ pydocstyle = "^6.1.1"
 mypy = "^0.910"
 types-requests = "^2.26.1"
 isort = "^5.10.1"
+ruff = "^0.1.0"
 
 [tool.isort]
 profile = "black"

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,19 @@
+target-version = "py310"
+line-length = 100
+
+exclude = [
+    ".git",
+    "__pycache__",
+    ".venv",
+    "venv",
+    "build",
+    "dist",
+    ".secrets",
+    ".vscode"
+]
+
+[lint]
+extend-select = ["C901"]
+ignore = []
+[lint.mccabe]
+max-complexity = 14

--- a/tap_stripe/client.py
+++ b/tap_stripe/client.py
@@ -1,8 +1,9 @@
 """REST client handling, including stripeStream base class."""
 
 from datetime import datetime
-from typing import Any, Dict, Iterable, Optional, cast
+from typing import Any, Callable, Dict, Iterable, Optional, cast
 
+import backoff
 import requests
 from requests.exceptions import JSONDecodeError
 from memoization import cached
@@ -11,8 +12,6 @@ from hotglue_singer_sdk.authenticators import BearerTokenAuthenticator
 from hotglue_singer_sdk.helpers.jsonpath import extract_jsonpath
 from hotglue_singer_sdk.streams import RESTStream
 from pendulum import parse
-from typing import Any, Callable, Dict, Iterable, Optional
-import backoff
 from hotglue_singer_sdk.exceptions import RetriableAPIError, FatalAPIError
 
 import singer
@@ -117,12 +116,12 @@ class stripeStream(RESTStream):
             return not_sync_invoice_status.split(",")
         return ["deleted"]
 
-    def parse_response(self, response: requests.Response) -> Iterable[dict]:
+    def parse_response(self, response: requests.Response) -> Iterable[dict]:  # noqa: C901
         decorated_request = self.request_decorator(self._request)
         base_url = "/".join(self.url_base.split("/")[:-2])
         try:
             records = extract_jsonpath(self.records_jsonpath, input=response.json())
-        except:
+        except Exception:
             records = response
 
         if self.name == "plans" and self.path == "events":


### PR DESCRIPTION
This PR implements automatic linting with Ruff via a GHA workflow that runs` ruff check .` that triggers on PRs and pushes.

Standard conventions are defined in `ruff.toml`

Fixed duplicate imports and general Exception issues in` tap_stripe/client.py` as well

We exclude the complexity check for the `parse_response()` function

Confirmed the GHA workflow completed after opening this PR:
<img width="1504" height="753" alt="image" src="https://github.com/user-attachments/assets/2217802f-56e9-49f9-b5b2-1ee5c93ec596" />
