### PR TITLE
Classify Stripe restricted-key permission errors as invalid credentials

### DIFF
--- a/tap_stripe/client.py
+++ b/tap_stripe/client.py
@@ -298,23 +298,10 @@ class stripeStream(RESTStream):
             f"{response.text} for path: {self.path}"
         )
 
-    def is_invalid_credentials_response(self, response: requests.Response) -> bool:
-        """Return True when the response indicates invalid credentials."""
-        if response.status_code == 401:
-            return True
-
-        if response.status_code != 403:
-            return False
-
-        try:
-            error = (response.json() or {}).get("error") or {}
-        except JSONDecodeError:
-            return False
-
-        return error.get("type") == "permission_denied"
-
     def validate_response(self, response: requests.Response, is_csv_stream: bool = False) -> None:
-        if self.is_invalid_credentials_response(response):
+        if response.status_code == 401 or (
+            response.status_code == 403 and "permission_denied" in response.text
+        ):
             msg = self.response_error_message(response)
             raise InvalidCredentialsError(msg)
         if (

--- a/tap_stripe/client.py
+++ b/tap_stripe/client.py
@@ -298,8 +298,23 @@ class stripeStream(RESTStream):
             f"{response.text} for path: {self.path}"
         )
 
-    def validate_response(self, response: requests.Response, is_csv_stream: bool = False) -> None:
+    def is_invalid_credentials_response(self, response: requests.Response) -> bool:
+        """Return True when the response indicates invalid credentials."""
         if response.status_code == 401:
+            return True
+
+        if response.status_code != 403:
+            return False
+
+        try:
+            error = (response.json() or {}).get("error") or {}
+        except JSONDecodeError:
+            return False
+
+        return error.get("type") == "permission_denied"
+
+    def validate_response(self, response: requests.Response, is_csv_stream: bool = False) -> None:
+        if self.is_invalid_credentials_response(response):
             msg = self.response_error_message(response)
             raise InvalidCredentialsError(msg)
         if (

--- a/tap_stripe/tests/test_client.py
+++ b/tap_stripe/tests/test_client.py
@@ -5,7 +5,6 @@ import json
 import pytest
 import requests
 from hotglue_etl_exceptions import InvalidCredentialsError
-from hotglue_singer_sdk.exceptions import FatalAPIError
 
 from tap_stripe.client import stripeStream
 
@@ -48,16 +47,4 @@ def test_validate_response_classifies_permission_denied_as_invalid_credentials()
     )
 
     with pytest.raises(InvalidCredentialsError):
-        stream.validate_response(response)
-
-
-def test_validate_response_keeps_other_forbidden_errors_fatal():
-    """Keep unrelated forbidden responses classified as fatal errors."""
-    stream = make_stream()
-    response = make_response(
-        403,
-        {"error": {"type": "invalid_request_error", "message": "Request failed."}},
-    )
-
-    with pytest.raises(FatalAPIError):
         stream.validate_response(response)

--- a/tap_stripe/tests/test_client.py
+++ b/tap_stripe/tests/test_client.py
@@ -1,0 +1,63 @@
+"""Tests for Stripe client error classification."""
+
+import json
+
+import pytest
+import requests
+from hotglue_etl_exceptions import InvalidCredentialsError
+from hotglue_singer_sdk.exceptions import FatalAPIError
+
+from tap_stripe.client import stripeStream
+
+
+class TestStripeStream(stripeStream):
+    """Minimal stream for response validation tests."""
+
+    name = "events"
+    path = "events"
+
+
+def make_response(status_code, payload):
+    """Build a JSON response object for tests."""
+    response = requests.Response()
+    response.status_code = status_code
+    response._content = json.dumps(payload).encode("utf-8")
+    response.headers["Content-Type"] = "application/json"
+    return response
+
+
+def make_stream():
+    """Create a stream instance without initializing the SDK base class."""
+    stream = object.__new__(TestStripeStream)
+    stream.ignore_statuscode = []
+    stream.extra_retry_statuses = []
+    return stream
+
+
+def test_validate_response_classifies_permission_denied_as_invalid_credentials():
+    """Treat restricted-key permission errors as invalid credentials."""
+    stream = make_stream()
+    response = make_response(
+        403,
+        {
+            "error": {
+                "type": "permission_denied",
+                "message": "This restricted key does not have the required event_read permission.",
+            }
+        },
+    )
+
+    with pytest.raises(InvalidCredentialsError):
+        stream.validate_response(response)
+
+
+def test_validate_response_keeps_other_forbidden_errors_fatal():
+    """Keep unrelated forbidden responses classified as fatal errors."""
+    stream = make_stream()
+    response = make_response(
+        403,
+        {"error": {"type": "invalid_request_error", "message": "Request failed."}},
+    )
+
+    with pytest.raises(FatalAPIError):
+        stream.validate_response(response)


### PR DESCRIPTION
Treat Stripe `403` responses with `error.type == "permission_denied"` as `InvalidCredentialsError` instead of a generic fatal API error.

Also adds a focused regression test covering the restricted-key permission case and confirms other `403` responses remain fatal.