### PR TITLE
HGI-10655 | Classify Stripe 403 responses as invalid credentials

### DIFF
--- a/tap_stripe/client.py
+++ b/tap_stripe/client.py
@@ -299,9 +299,7 @@ class stripeStream(RESTStream):
         )
 
     def validate_response(self, response: requests.Response, is_csv_stream: bool = False) -> None:
-        if response.status_code == 401 or (
-            response.status_code == 403 and "permission_denied" in response.text
-        ):
+        if response.status_code in [401, 403]:
             msg = self.response_error_message(response)
             raise InvalidCredentialsError(msg)
         if (

--- a/tap_stripe/streams.py
+++ b/tap_stripe/streams.py
@@ -831,7 +831,7 @@ class UsageRecordsStream(stripeStream):
     ).to_dict()
 
     def validate_response(self, response: requests.Response) -> None:
-        if response.status_code == 401:
+        if response.status_code in [401, 403]:
             msg = self.response_error_message(response)
             raise InvalidCredentialsError(msg)
 

--- a/tap_stripe/tests/test_client.py
+++ b/tap_stripe/tests/test_client.py
@@ -7,6 +7,7 @@ import requests
 from hotglue_etl_exceptions import InvalidCredentialsError
 
 from tap_stripe.client import stripeStream
+from tap_stripe.streams import UsageRecordsStream
 
 
 class TestStripeStream(stripeStream):
@@ -14,6 +15,10 @@ class TestStripeStream(stripeStream):
 
     name = "events"
     path = "events"
+
+
+class TestUsageRecordsValidationStream(UsageRecordsStream):
+    """Minimal usage-records stream for response validation tests."""
 
 
 def make_response(status_code, payload):
@@ -34,7 +39,7 @@ def make_stream():
 
 
 def test_validate_response_classifies_permission_denied_as_invalid_credentials():
-    """Treat restricted-key permission errors as invalid credentials."""
+    """Treat any 403 response as invalid credentials in the base client path."""
     stream = make_stream()
     response = make_response(
         403,
@@ -45,6 +50,18 @@ def test_validate_response_classifies_permission_denied_as_invalid_credentials()
             }
         },
     )
+
+    with pytest.raises(InvalidCredentialsError):
+        stream.validate_response(response)
+
+
+def test_usage_records_validate_response_classifies_403_as_invalid_credentials():
+    """Treat any 403 response as invalid credentials in the usage-records path."""
+    stream = object.__new__(TestUsageRecordsValidationStream)
+    stream.ignore_statuscode = []
+    stream.extra_retry_statuses = []
+    stream.path = "subscription_items/{subscription_item_id}/usage_record_summaries"
+    response = make_response(403, {"error": {"message": "Forbidden"}})
 
     with pytest.raises(InvalidCredentialsError):
         stream.validate_response(response)


### PR DESCRIPTION
This keeps the fix scoped to response classification.

- treat `401` and `403` responses as `InvalidCredentialsError` in the shared Stripe client path
- mirror the same `401`/`403` handling in the usage records stream override
- add focused regression coverage for `403` classification

Verification: `python3 -m py_compile tap_stripe/client.py tap_stripe/streams.py tap_stripe/tests/test_client.py` (`pytest` is not installed in this environment).